### PR TITLE
Added new HX_XBOXONE platform define

### DIFF
--- a/src/hx/Debug.cpp
+++ b/src/hx/Debug.cpp
@@ -85,7 +85,7 @@ static void CriticalErrorHandler(String inErr, bool allowFixup)
 
     DBGLOG("Critical Error: %s\n", inErr.utf8_str());
 
-#if defined(HX_WINDOWS) && !defined(HX_WINRT)
+#if defined(HX_WINDOWS) && !defined(HX_WINRT) && !defined(HX_XBOXONE)
     MessageBoxA(0, inErr.utf8_str(), "Critial Error - program must terminate",
         MB_ICONEXCLAMATION|MB_OK);
 #endif

--- a/src/hx/StdLibs.cpp
+++ b/src/hx/StdLibs.cpp
@@ -238,7 +238,7 @@ int __hxcpp_irand(int inMax)
 
 void __hxcpp_stdlibs_boot()
 {
-   #if defined(_MSC_VER) && !defined(HX_WINRT)
+   #if defined(_MSC_VER) && !defined(HX_WINRT) && !defined(HX_XBOXONE)
    HMODULE kernel32 = LoadLibraryA("kernel32");
    if (kernel32)
    {


### PR DESCRIPTION
Added the HX_XBOXONE define to exclude calls to windows specific libraries
while retaining most other windows concepts.