### PR TITLE
Add support for HXCPP_MSVC_VERSION env variable to switch targeted VC

### DIFF
--- a/toolchain/msvc-setup.bat
+++ b/toolchain/msvc-setup.bat
@@ -8,8 +8,16 @@ setlocal enabledelayedexpansion
 	@echo HXCPP_VARS
 	@set
 ) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
-	for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
-		@set InstallDir=%%i
+	cd /D "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
+	if defined HXCPP_MSVC_VERSION (
+		for /f "usebackq tokens=*" %%i in (`vswhere.exe -version "[%HXCPP_MSVC_VERSION%,)" -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+			@set InstallDir=%%i
+		)
+	)
+	else (
+		for /f "usebackq tokens=*" %%i in (`vswhere.exe -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+			@set InstallDir=%%i
+		)
 	)
 	@if exist "!InstallDir!\Common7\Tools\VsDevCmd.bat" (
 		@call "!InstallDir!\Common7\Tools\VsDevCmd.bat" -arch=x86 -app_platform=Desktop -no_logo

--- a/toolchain/msvc64-setup.bat
+++ b/toolchain/msvc64-setup.bat
@@ -21,6 +21,7 @@ setlocal enabledelayedexpansion
 	)
 	@if exist "!InstallDir!\Common7\Tools\VsDevCmd.bat" (
 		@call "!InstallDir!\Common7\Tools\VsDevCmd.bat" -arch=amd64 -app_platform=Desktop -no_logo
+		@echo HXCPP_VARS
 		@set
 	) else (
 		echo Warning: Could not find Visual Studio VsDevCmd

--- a/toolchain/msvc64-setup.bat
+++ b/toolchain/msvc64-setup.bat
@@ -9,15 +9,21 @@ setlocal enabledelayedexpansion
 		@set
 	)
 ) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
-	for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
-		@set InstallDir=%%i
+	cd /D "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
+	@if defined HXCPP_MSVC_VERSION (
+		for /f "usebackq tokens=*" %%i in (`vswhere.exe -version "[%HXCPP_MSVC_VERSION%,)" -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+			@set InstallDir=%%i
+		)
+	) else (
+		for /f "usebackq tokens=*" %%i in (`vswhere.exe -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+			@set InstallDir=%%i
+		)
 	)
 	@if exist "!InstallDir!\Common7\Tools\VsDevCmd.bat" (
 		@call "!InstallDir!\Common7\Tools\VsDevCmd.bat" -arch=amd64 -app_platform=Desktop -no_logo
-		@echo HXCPP_VARS
 		@set
 	) else (
-		echo Warning: Could not find Visual Studio 2017 VsDevCmd
+		echo Warning: Could not find Visual Studio VsDevCmd
 	)
 ) else if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" (
 	@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64 -app_platform=Desktop -no_logo


### PR DESCRIPTION
Fixes local issue of the Haxe integration always using VS 2019 when both 2017 and 2019 were installed, but 2017 was desired.

Usage: Set env var HXCPP_MSVC_VERSION to "15.0" for VS 2017, "16.0" for VS 2019 (only relevant when the next major VS version is released). This does not work on 2015 and below due to 'vswhere.exe' being a pretty recent addition.